### PR TITLE
fix checking MSB of the tag bytes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: stable
 
     - name: Test
       run: go test -v ./...


### PR DESCRIPTION
this PR fixes how we validate tag to match EMV spec

<img width="724" alt="image" src="https://github.com/user-attachments/assets/b4750feb-aa6d-487b-8ff9-5bfea86483d3">
