### PR TITLE
add CreateTagsCopy method

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - Unmarshal BER-TLV data into Go structs
 - Support for both simple and composite TLV tags.
 - Easy pretty-printing of decoded TLV structures for debugging and analysis.
+- Selective copying of TLV data by tag names.
 
 ## Installation
 
@@ -75,9 +76,10 @@ func TestEncodeDecode(t *testing.T) {
 - **Encode**: The `bertlv.Encode` encodes TLV objects into a binary format.
 - **Decode**: The `bertlv.Decode` decodes a binary value back into a TLV objects.
 - **FindTagByPath**: The `bertlv.FindTagByPath` returns the first TLV object matching the specified path (e.g., "6F.A5.BF0C.61.50").
-- - **FindFirstTag**: The `bertlv.FindFirstTag` returns the first TLV object matching the specified name (e.g., "A5"). It searches recursively.
+- **FindFirstTag**: The `bertlv.FindFirstTag` returns the first TLV object matching the specified name (e.g., "A5"). It searches recursively.
 - **PrettyPrint**: The `bertlv.PrettyPrint` visaulizes the TLV structure in a readable format.
 - **Unmarshal**: The `bertlv.Unmarshal` converts TLV objects into a Go struct using struct tags.
+- **CreateTagsCopy**: The `bertlv.CreateTagsCopy` creates a deep copy of TLVs containing only the specified tags.
 
 ### TLV Creation
 You can create TLV objects using the following helper functions (preferred way):
@@ -121,6 +123,26 @@ type EMVData struct {
 data := []bertlv.TLV{...} // Your TLV data
 var emvData EMVData
 err := bertlv.Unmarshal(data, &emvData)
+```
+
+### Creating filtered copies of TLV data
+
+The `bertlv.CreateTagsCopy` function allows you to create a deep copy of a TLV slice containing only the specified tags. Only top level tags are copied, and if a tag is a composite tag, its entire subtree is copied.
+
+```go
+// Original TLV data containing sensitive information
+originalData := []bertlv.TLV{
+    bertlv.NewTag("9F02", []byte{0x00, 0x00, 0x00, 0x01, 0x23, 0x45}), // Amount
+    bertlv.NewTag("5A", []byte{0x41, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77}), // PAN (sensitive)
+    bertlv.NewTag("57", []byte{0x41, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0xD2, 0x30, 0x12}), // Track2 (sensitive)
+    bertlv.NewTag("9F1A", []byte{0x08, 0x40}), // Terminal Country Code
+}
+
+// Create a copy with only non-sensitive tags
+safeData := bertlv.CreateTagsCopy(originalData, "9F02", "9F1A")
+
+// safeData now contains only the Amount and Terminal Country Code
+// Original data remains unchanged
 ```
 
 ## Contribution

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ func TestEncodeDecode(t *testing.T) {
 - **FindFirstTag**: The `bertlv.FindFirstTag` returns the first TLV object matching the specified name (e.g., "A5"). It searches recursively.
 - **PrettyPrint**: The `bertlv.PrettyPrint` visaulizes the TLV structure in a readable format.
 - **Unmarshal**: The `bertlv.Unmarshal` converts TLV objects into a Go struct using struct tags.
-- **CreateTagsCopy**: The `bertlv.CreateTagsCopy` creates a deep copy of TLVs containing only the specified tags.
+- **CopyTags**: The `bertlv.CopyTags` creates a deep copy of TLVs containing only the specified tags.
 
 ### TLV Creation
 You can create TLV objects using the following helper functions (preferred way):
@@ -127,7 +127,7 @@ err := bertlv.Unmarshal(data, &emvData)
 
 ### Creating filtered copies of TLV data
 
-The `bertlv.CreateTagsCopy` function allows you to create a deep copy of a TLV slice containing only the specified tags. Only top level tags are copied, and if a tag is a composite tag, its entire subtree is copied.
+The `bertlv.CopyTags` function allows you to create a deep copy of a TLV slice containing only the specified tags. Only top level tags are copied, and if a tag is a composite tag, its entire subtree is copied.
 
 ```go
 // Original TLV data containing sensitive information
@@ -139,7 +139,7 @@ originalData := []bertlv.TLV{
 }
 
 // Create a copy with only non-sensitive tags
-safeData := bertlv.CreateTagsCopy(originalData, "9F02", "9F1A")
+safeData := bertlv.CopyTags(originalData, "9F02", "9F1A")
 
 // safeData now contains only the Amount and Terminal Country Code
 // Original data remains unchanged

--- a/tlv.go
+++ b/tlv.go
@@ -390,10 +390,10 @@ func Unmarshal(tlvs []TLV, s any) error {
 	return nil
 }
 
-// CreateTagsCopy creates a new slice containing only TLVs with the specified tags.
+// CopyTags creates a new slice containing only TLVs with the specified tags.
 // It performs a deep copy of the matching TLVs, ensuring the original data is not modified.
 // When a parent TLV is included in the tags list, its entire subtree is copied.
-func CreateTagsCopy(tlvs []TLV, tags ...string) []TLV {
+func CopyTags(tlvs []TLV, tags ...string) []TLV {
 	if len(tlvs) == 0 || len(tags) == 0 {
 		return nil
 	}

--- a/tlv_test.go
+++ b/tlv_test.go
@@ -143,8 +143,7 @@ func TestUnmarshalEdgeCases(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestCreateTagsCopy(t *testing.T) {
-	// Test cases
+func TestCopyTags(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    []bertlv.TLV
@@ -238,7 +237,7 @@ func TestCreateTagsCopy(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := bertlv.CreateTagsCopy(tc.input, tc.tags...)
+			result := bertlv.CopyTags(tc.input, tc.tags...)
 
 			require.Equal(t, tc.expected, result)
 
@@ -256,8 +255,7 @@ func TestCreateTagsCopy(t *testing.T) {
 	}
 }
 
-func BenchmarkCreateTagsCopy(b *testing.B) {
-	// Create a complex TLV structure for benchmarking
+func BenchmarkCopyTags(b *testing.B) {
 	input := []bertlv.TLV{
 		bertlv.NewComposite("6F", // File Control Information (FCI) Template
 			bertlv.NewTag("84", []byte{0x32, 0x50, 0x41, 0x59, 0x2E, 0x53, 0x59, 0x53, 0x2E, 0x44, 0x44, 0x46, 0x30, 0x31}),
@@ -282,7 +280,6 @@ func BenchmarkCreateTagsCopy(b *testing.B) {
 		bertlv.NewTag("9F36", []byte{0x00, 0x01}),
 	}
 
-	// Define different benchmark scenarios
 	benchmarks := []struct {
 		name    string
 		tags    []string
@@ -326,7 +323,7 @@ func BenchmarkCreateTagsCopy(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				result := bertlv.CreateTagsCopy(input, bm.tags...)
+				result := bertlv.CopyTags(input, bm.tags...)
 				// Force compiler to evaluate result to prevent optimization
 				if len(result) > 100000 {
 					b.Fatalf("unexpected result length")


### PR DESCRIPTION
Here is what is possible now:
```go
// Original TLV data containing sensitive information
originalData := []bertlv.TLV{
    bertlv.NewTag("9F02", []byte{0x00, 0x00, 0x00, 0x01, 0x23, 0x45}), // Amount
    bertlv.NewTag("5A", []byte{0x41, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77}), // PAN (sensitive)
    bertlv.NewTag("57", []byte{0x41, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0xD2, 0x30, 0x12}), // Track2 (sensitive)
    bertlv.NewTag("9F1A", []byte{0x08, 0x40}), // Terminal Country Code
}

// Create a copy with only non-sensitive tags
safeData := bertlv.CreateTagsCopy(originalData, "9F02", "9F1A")
```