### PR TITLE
Fix slice-bounds panic on malformed long-form TLV length

### DIFF
--- a/example_optimization_test.go
+++ b/example_optimization_test.go
@@ -14,24 +14,24 @@ import (
 func ExampleBuildTagMap() {
 	// EMV TLV data from a card response
 	data, _ := hex.DecodeString("6F468407A0000000031010A53B500B56495341204352454449548701015F2D02656E9F38189F66049F02069F03069F1A0295055F2A029A039C019F3704BF0C089F5A051108400840")
-	
+
 	tlvs, err := Decode(data)
 	if err != nil {
 		log.Fatal(err)
 	}
-	
+
 	// Build tag map for fast lookups
 	tagMap := BuildTagMap(tlvs)
-	
+
 	// Fast O(1) lookups - use FindFirst for single tag access
 	if aid, found := FindFirst(tagMap, "84"); found {
 		fmt.Printf("AID: %X\n", aid.Value)
 	}
-	
+
 	if label, found := FindFirst(tagMap, "50"); found {
 		fmt.Printf("Application Label: %s\n", string(label.Value))
 	}
-	
+
 	// Output:
 	// AID: A0000000031010
 	// Application Label: VISA CREDIT
@@ -41,24 +41,24 @@ func ExampleBuildTagMap() {
 func ExampleBuildTagMap_performance() {
 	data, _ := hex.DecodeString("6F468407A0000000031010A53B500B56495341204352454449548701015F2D02656E9F38189F66049F02069F03069F1A0295055F2A029A039C019F3704BF0C089F5A051108400840")
 	tlvs, _ := Decode(data)
-	
+
 	// For single tag lookup, use FindFirstTag (simpler)
 	aid, found := FindFirstTag(tlvs, "84")
 	if found {
 		fmt.Printf("Single lookup - AID: %X\n", aid.Value)
 	}
-	
+
 	// For multiple tag lookups, use BuildTagMap (faster)
 	tagMap := BuildTagMap(tlvs)
 	tagsToFind := []string{"84", "50", "87", "9F38", "5F2D"}
-	
+
 	fmt.Println("Multiple lookups:")
 	for _, tag := range tagsToFind {
 		if tlv, found := FindFirst(tagMap, tag); found {
 			fmt.Printf("  Tag %s: %X\n", tag, tlv.Value)
 		}
 	}
-	
+
 	// Output:
 	// Single lookup - AID: A0000000031010
 	// Multiple lookups:
@@ -74,20 +74,20 @@ func ExampleBuildTagMap_emvPaymentProcessing() {
 	// Simulate EMV card response with nested tags - using the simpler complexEMVData
 	data, _ := hex.DecodeString(complexEMVData)
 	tlvs, _ := Decode(data)
-	
+
 	// Build tag map once for the transaction
 	tagMap := BuildTagMap(tlvs)
-	
+
 	// EMV processing requires multiple tag lookups
 	emvTags := map[string]string{
 		"84":   "Application Identifier (AID)",
-		"50":   "Application Label", 
+		"50":   "Application Label",
 		"87":   "Application Priority Indicator",
 		"9F38": "Processing Options Data Object List (PDOL)",
 		"5F2D": "Language Preference",
 		"9F5A": "Application Program Identifier",
 	}
-	
+
 	fmt.Println("EMV Card Analysis:")
 	// Process tags in a specific order for consistent output
 	tagOrder := []string{"84", "50", "87", "9F38", "5F2D", "9F5A"}
@@ -98,13 +98,13 @@ func ExampleBuildTagMap_emvPaymentProcessing() {
 			}
 		}
 	}
-	
+
 	// Get performance statistics
 	stats := GetTagMapStats(tagMap)
 	fmt.Printf("\nTag Map Statistics:\n")
 	fmt.Printf("  Total Tags: %d\n", stats.TotalTags)
 	fmt.Printf("  Memory Usage: ~%d bytes\n", stats.MemoryEstimate)
-	
+
 	// Output:
 	// EMV Card Analysis:
 	//   Application Identifier (AID) (84): A0000000031010
@@ -123,19 +123,19 @@ func ExampleBuildTagMap_emvPaymentProcessing() {
 func ExampleFindFirst() {
 	data, _ := hex.DecodeString(simpleEMVData)
 	tlvs, _ := Decode(data)
-	
+
 	tagMap := BuildTagMap(tlvs)
-	
+
 	// Find the first occurrence of a tag
 	aid, found := FindFirst(tagMap, "84")
 	if found {
 		fmt.Printf("AID found: %X\n", aid.Value)
 	}
-	
+
 	// Failed lookup
 	_, found = FindFirst(tagMap, "NONEXISTENT")
 	fmt.Printf("Non-existent tag found: %v\n", found)
-	
+
 	// Output:
 	// AID found: A0000000031010
 	// Non-existent tag found: false
@@ -155,7 +155,7 @@ func ExampleFind() {
 			},
 		},
 		{
-			Tag: "77", // Second template  
+			Tag: "77", // Second template
 			TLVs: []TLV{
 				{Tag: "9F10", Value: []byte{0x03, 0x04}},
 				{Tag: "84", Value: []byte{0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x98}},
@@ -169,9 +169,9 @@ func ExampleFind() {
 			},
 		},
 	}
-	
+
 	tagMap := BuildTagMap(tlvsWithDuplicates)
-	
+
 	// Find all instances of tag 9F10 (Issuer Application Data)
 	if instances, found := Find(tagMap, "9F10"); found {
 		fmt.Printf("Found %d instances of tag 9F10:\n", len(instances))
@@ -179,7 +179,7 @@ func ExampleFind() {
 			fmt.Printf("  Instance %d: %X\n", i+1, instance.Value)
 		}
 	}
-	
+
 	// Find all Application Labels
 	if labels, found := Find(tagMap, "50"); found {
 		fmt.Printf("\nFound %d Application Labels:\n", len(labels))
@@ -187,7 +187,7 @@ func ExampleFind() {
 			fmt.Printf("  %d: %s\n", i+1, string(label.Value))
 		}
 	}
-	
+
 	// Output:
 	// Found 3 instances of tag 9F10:
 	//   Instance 1: 0102

--- a/optimization.go
+++ b/optimization.go
@@ -5,7 +5,7 @@
 package bertlv
 
 // BuildTagMap creates a flattened map of all tags for O(1) lookups.
-// This optimization is particularly useful for applications that need to 
+// This optimization is particularly useful for applications that need to
 // access multiple tags from the same TLV structure repeatedly, such as
 // EMV payment processing where tag lookups are performance-critical.
 //
@@ -15,13 +15,14 @@ package bertlv
 // that appear in different constructed TLVs.
 //
 // Usage:
-//   tagMap := BuildTagMap(tlvs)
-//   if tags, found := tagMap["84"]; found {
-//       // Process tag(s) - O(1) operation
-//       for _, tag := range tags {
-//           // Handle each occurrence
-//       }
-//   }
+//
+//	tagMap := BuildTagMap(tlvs)
+//	if tags, found := tagMap["84"]; found {
+//	    // Process tag(s) - O(1) operation
+//	    for _, tag := range tags {
+//	        // Handle each occurrence
+//	    }
+//	}
 //
 // Note: Duplicate tags within constructed TLVs are preserved in the order
 // they are encountered during depth-first traversal.
@@ -29,14 +30,14 @@ func BuildTagMap(tlvs []TLV) map[string][]TLV {
 	if len(tlvs) == 0 {
 		return make(map[string][]TLV)
 	}
-	
+
 	// Estimate map size to reduce reallocations
 	estimatedSize := estimateTagCount(tlvs)
 	tagMap := make(map[string][]TLV, estimatedSize)
-	
+
 	// Recursively flatten all tags including nested ones
 	flattenTags(tlvs, tagMap)
-	
+
 	return tagMap
 }
 
@@ -46,7 +47,7 @@ func flattenTags(tlvs []TLV, tagMap map[string][]TLV) {
 	for _, tlv := range tlvs {
 		// Always append - preserve all instances
 		tagMap[tlv.Tag] = append(tagMap[tlv.Tag], tlv)
-		
+
 		// Recursively process nested TLVs
 		if len(tlv.TLVs) > 0 {
 			flattenTags(tlv.TLVs, tagMap)
@@ -58,14 +59,14 @@ func flattenTags(tlvs []TLV, tagMap map[string][]TLV) {
 // This helps reduce map reallocations during building.
 func estimateTagCount(tlvs []TLV) int {
 	count := len(tlvs)
-	
+
 	// Add estimated nested tags (assume average of 2x nesting)
 	for _, tlv := range tlvs {
 		if len(tlv.TLVs) > 0 {
 			count += estimateTagCount(tlv.TLVs)
 		}
 	}
-	
+
 	return count
 }
 
@@ -100,22 +101,22 @@ func GetTagMapStats(tagMap map[string][]TLV) TagMapStats {
 	stats := TagMapStats{
 		UniqueTags: len(tagMap),
 	}
-	
+
 	// Count total tags and calculate memory estimate
 	for tag, instances := range tagMap {
 		stats.TotalTags += len(instances)
 		if len(instances) > 1 {
 			stats.DuplicateTags += len(instances) - 1
 		}
-		
+
 		// Memory estimate
 		stats.MemoryEstimate += int64(len(tag)) * int64(len(instances)) // Tag strings
 		for _, tlv := range instances {
-			stats.MemoryEstimate += int64(len(tlv.Value))     // Value bytes
-			stats.MemoryEstimate += 64                        // Struct overhead estimate
+			stats.MemoryEstimate += int64(len(tlv.Value)) // Value bytes
+			stats.MemoryEstimate += 64                    // Struct overhead estimate
 		}
 		stats.MemoryEstimate += int64(len(instances)) * 8 // Slice overhead
 	}
-	
+
 	return stats
 }

--- a/optimization_test.go
+++ b/optimization_test.go
@@ -15,7 +15,7 @@ import (
 var (
 	// Simple EMV AID Response with basic tags
 	simpleEMVData = "6F468407A0000000031010A53B500B56495341204352454449548701015F2D02656E9F38189F66049F02069F03069F1A0295055F2A029A039C019F3704BF0C089F5A051108400840"
-	
+
 	// Complex nested EMV data with multiple levels - same as simpleEMVData for now
 	complexEMVData = simpleEMVData
 )
@@ -24,22 +24,22 @@ func TestBuildTagMap(t *testing.T) {
 	// Test with simple TLV structure
 	data, err := hex.DecodeString(simpleEMVData)
 	require.NoError(t, err)
-	
+
 	tlvs, err := Decode(data)
 	require.NoError(t, err)
-	
+
 	tagMap := BuildTagMap(tlvs)
-	
+
 	// Verify expected tags are present
 	expectedTags := []string{"6F", "84", "A5", "50", "87", "5F2D", "9F38", "BF0C", "9F5A"}
-	
+
 	for _, expectedTag := range expectedTags {
 		instances, found := tagMap[expectedTag]
 		require.True(t, found, "Expected tag %s not found in map", expectedTag)
 		require.Greater(t, len(instances), 0, "Tag %s should have at least one instance", expectedTag)
 		require.Equal(t, expectedTag, instances[0].Tag)
 	}
-	
+
 	// Verify tag map size is reasonable
 	require.Greater(t, len(tagMap), 5, "Tag map should contain multiple tags")
 }
@@ -64,9 +64,9 @@ func TestBuildTagMapNestedStructures(t *testing.T) {
 			},
 		},
 	}
-	
+
 	tagMap := BuildTagMap(nestedTLVs)
-	
+
 	// Verify all tags are flattened into map
 	expectedTags := []string{"70", "84", "A5", "50", "9F38"}
 	for _, expectedTag := range expectedTags {
@@ -84,7 +84,7 @@ func TestBuildTagMapDuplicateTags(t *testing.T) {
 			Tag: "70", // First template
 			TLVs: []TLV{
 				{Tag: "84", Value: []byte{0xA0, 0x00, 0x00, 0x00, 0x03}}, // AID
-				{Tag: "9F10", Value: []byte{0x01, 0x02, 0x03}}, // Issuer Application Data
+				{Tag: "9F10", Value: []byte{0x01, 0x02, 0x03}},           // Issuer Application Data
 				{Tag: "50", Value: []byte("VISA")},
 			},
 		},
@@ -92,7 +92,7 @@ func TestBuildTagMapDuplicateTags(t *testing.T) {
 			Tag: "77", // Second template
 			TLVs: []TLV{
 				{Tag: "84", Value: []byte{0xA0, 0x00, 0x00, 0x00, 0x04}}, // Different AID
-				{Tag: "9F10", Value: []byte{0x04, 0x05, 0x06}}, // Different Issuer Application Data
+				{Tag: "9F10", Value: []byte{0x04, 0x05, 0x06}},           // Different Issuer Application Data
 				{Tag: "50", Value: []byte("MASTERCARD")},
 			},
 		},
@@ -103,43 +103,43 @@ func TestBuildTagMapDuplicateTags(t *testing.T) {
 			},
 		},
 	}
-	
+
 	tagMap := BuildTagMap(tlvsWithDuplicates)
-	
+
 	// Test that duplicate tags are preserved
 	instances9F10, found := tagMap["9F10"]
 	require.True(t, found, "Tag 9F10 should be in the map")
 	require.Equal(t, 3, len(instances9F10), "Should have 3 instances of tag 9F10")
-	
+
 	// Verify all three different values are preserved
 	expectedValues := [][]byte{
 		{0x01, 0x02, 0x03},
 		{0x04, 0x05, 0x06},
 		{0x07, 0x08, 0x09},
 	}
-	
+
 	for i, instance := range instances9F10 {
 		require.Equal(t, "9F10", instance.Tag)
 		require.Equal(t, expectedValues[i], instance.Value, "Instance %d value mismatch", i)
 	}
-	
+
 	// Test duplicate AID tags
 	instances84, found := tagMap["84"]
 	require.True(t, found)
 	require.Equal(t, 2, len(instances84), "Should have 2 instances of tag 84")
-	
+
 	// Test duplicate Application Label tags
 	instances50, found := tagMap["50"]
 	require.True(t, found)
 	require.Equal(t, 2, len(instances50), "Should have 2 instances of tag 50")
 	require.Equal(t, "VISA", string(instances50[0].Value))
 	require.Equal(t, "MASTERCARD", string(instances50[1].Value))
-	
+
 	// Test template tags
 	templates, found := tagMap["70"]
 	require.True(t, found)
 	require.Equal(t, 1, len(templates))
-	
+
 	templates, found = tagMap["77"]
 	require.True(t, found)
 	require.Equal(t, 1, len(templates))
@@ -148,17 +148,17 @@ func TestBuildTagMapDuplicateTags(t *testing.T) {
 func TestFindFirst(t *testing.T) {
 	data, err := hex.DecodeString(simpleEMVData)
 	require.NoError(t, err)
-	
+
 	tlvs, err := Decode(data)
 	require.NoError(t, err)
-	
+
 	tagMap := BuildTagMap(tlvs)
-	
+
 	// Test successful lookup - returns first instance
 	tlv, found := FindFirst(tagMap, "84")
 	require.True(t, found)
 	require.Equal(t, "84", tlv.Tag)
-	
+
 	// Test failed lookup
 	_, found = FindFirst(tagMap, "NONEXISTENT")
 	require.False(t, found)
@@ -180,21 +180,21 @@ func TestFind(t *testing.T) {
 			},
 		},
 	}
-	
+
 	tagMap := BuildTagMap(tlvsWithDuplicates)
-	
+
 	// Test finding all instances
 	instances, found := Find(tagMap, "9F10")
 	require.True(t, found)
 	require.Equal(t, 2, len(instances))
 	require.Equal(t, []byte{0x01}, instances[0].Value)
 	require.Equal(t, []byte{0x02}, instances[1].Value)
-	
+
 	// Test finding single instance
 	instances, found = Find(tagMap, "70")
 	require.True(t, found)
 	require.Equal(t, 1, len(instances))
-	
+
 	// Test not found
 	_, found = Find(tagMap, "NONEXISTENT")
 	require.False(t, found)
@@ -203,13 +203,13 @@ func TestFind(t *testing.T) {
 func TestGetTagMapStats(t *testing.T) {
 	data, err := hex.DecodeString(simpleEMVData)
 	require.NoError(t, err)
-	
+
 	tlvs, err := Decode(data)
 	require.NoError(t, err)
-	
+
 	tagMap := BuildTagMap(tlvs)
 	stats := GetTagMapStats(tagMap)
-	
+
 	require.Greater(t, stats.TotalTags, 0)
 	require.Greater(t, stats.UniqueTags, 0)
 	require.Equal(t, 0, stats.DuplicateTags, "Simple data should have no duplicates")
@@ -223,10 +223,10 @@ func TestGetTagMapStatsWithDuplicates(t *testing.T) {
 		{Tag: "77", TLVs: []TLV{{Tag: "9F10", Value: []byte{0x02}}}},
 		{Tag: "80", TLVs: []TLV{{Tag: "9F10", Value: []byte{0x03}}}},
 	}
-	
+
 	tagMap := BuildTagMap(tlvsWithDuplicates)
 	stats := GetTagMapStats(tagMap)
-	
+
 	require.Equal(t, 6, stats.TotalTags, "Should have 6 total tags (3 templates + 3 instances of 9F10)")
 	require.Equal(t, 4, stats.UniqueTags, "Should have 4 unique tags (70, 77, 80, 9F10)")
 	require.Equal(t, 2, stats.DuplicateTags, "Should have 2 duplicate instances of 9F10")
@@ -238,7 +238,7 @@ func TestGetTagMapStatsWithDuplicates(t *testing.T) {
 func BenchmarkFindFirstTag_Single(b *testing.B) {
 	data, _ := hex.DecodeString(simpleEMVData)
 	tlvs, _ := Decode(data)
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		FindFirstTag(tlvs, "84")
@@ -249,7 +249,7 @@ func BenchmarkFindFirstTag_Multiple(b *testing.B) {
 	data, _ := hex.DecodeString(simpleEMVData)
 	tlvs, _ := Decode(data)
 	tags := []string{"84", "50", "87", "9F38", "BF0C"}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, tag := range tags {
@@ -261,7 +261,7 @@ func BenchmarkFindFirstTag_Multiple(b *testing.B) {
 func BenchmarkBuildTagMap(b *testing.B) {
 	data, _ := hex.DecodeString(simpleEMVData)
 	tlvs, _ := Decode(data)
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		BuildTagMap(tlvs)
@@ -272,7 +272,7 @@ func BenchmarkTagMapLookup_Single(b *testing.B) {
 	data, _ := hex.DecodeString(simpleEMVData)
 	tlvs, _ := Decode(data)
 	tagMap := BuildTagMap(tlvs)
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		FindFirst(tagMap, "84")
@@ -284,7 +284,7 @@ func BenchmarkTagMapLookup_Multiple(b *testing.B) {
 	tlvs, _ := Decode(data)
 	tagMap := BuildTagMap(tlvs)
 	tags := []string{"84", "50", "87", "9F38", "BF0C"}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, tag := range tags {
@@ -297,7 +297,7 @@ func BenchmarkCompleteWorkflow_FindFirstTag(b *testing.B) {
 	data, _ := hex.DecodeString(simpleEMVData)
 	tlvs, _ := Decode(data)
 	tags := []string{"84", "50", "87", "9F38", "BF0C", "5F2D", "6F"}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, tag := range tags {
@@ -310,7 +310,7 @@ func BenchmarkCompleteWorkflow_TagMap(b *testing.B) {
 	data, _ := hex.DecodeString(simpleEMVData)
 	tlvs, _ := Decode(data)
 	tags := []string{"84", "50", "87", "9F38", "BF0C", "5F2D", "6F"}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		tagMap := BuildTagMap(tlvs)
@@ -325,7 +325,7 @@ func BenchmarkCompleteWorkflow_TagMapReused(b *testing.B) {
 	tlvs, _ := Decode(data)
 	tags := []string{"84", "50", "87", "9F38", "BF0C", "5F2D", "6F"}
 	tagMap := BuildTagMap(tlvs)
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, tag := range tags {
@@ -337,7 +337,7 @@ func BenchmarkCompleteWorkflow_TagMapReused(b *testing.B) {
 func BenchmarkNestedStructures_FindFirstTag(b *testing.B) {
 	data, _ := hex.DecodeString(complexEMVData)
 	tlvs, _ := Decode(data)
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		FindFirstTag(tlvs, "DF63")
@@ -347,7 +347,7 @@ func BenchmarkNestedStructures_FindFirstTag(b *testing.B) {
 func BenchmarkNestedStructures_TagMap(b *testing.B) {
 	data, _ := hex.DecodeString(complexEMVData)
 	tlvs, _ := Decode(data)
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		tagMap := BuildTagMap(tlvs)
@@ -359,7 +359,7 @@ func BenchmarkNestedStructures_TagMap(b *testing.B) {
 func BenchmarkMemoryUsage_BuildTagMap(b *testing.B) {
 	data, _ := hex.DecodeString(complexEMVData)
 	tlvs, _ := Decode(data)
-	
+
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -371,7 +371,7 @@ func BenchmarkMemoryUsage_BuildTagMap(b *testing.B) {
 func BenchmarkMemoryUsage_FindFirstTag(b *testing.B) {
 	data, _ := hex.DecodeString(complexEMVData)
 	tlvs, _ := Decode(data)
-	
+
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/tlv.go
+++ b/tlv.go
@@ -256,9 +256,23 @@ func decodeLength(data []byte) (int, int, error) {
 		return 0, 0, errors.New("length is incomplete")
 	}
 
+	// A length encoded in more than 8 bytes cannot fit in a 64-bit int. Reject it
+	// so the accumulation below cannot overflow into a bogus (possibly negative)
+	// value that would bypass the caller's bounds check and cause a
+	// slice-out-of-range panic on malformed input.
+	if lengthBytes > 8 {
+		return 0, 0, fmt.Errorf("length field too large: %d bytes", lengthBytes)
+	}
+
 	length := 0
 	for i := 1; i <= lengthBytes; i++ {
 		length = length<<8 | int(data[i])
+	}
+
+	// An 8-byte length with the high bit set overflows int's sign bit, producing a
+	// negative length. Reject it rather than passing it to a slice expression.
+	if length < 0 {
+		return 0, 0, errors.New("length overflow: value too large")
 	}
 
 	return length, lengthBytes + 1, nil

--- a/tlv.go
+++ b/tlv.go
@@ -162,8 +162,8 @@ func prettyPrint(tlvs []TLV, sb *strings.Builder, level int) {
 // bytes used to encode the length of the value field
 func encodeLength(length int) []byte {
 	if length < 128 {
-		// short form
-		return []byte{byte(length)}
+		// short form (length is < 128; mask keeps the conversion provably in range)
+		return []byte{byte(length & 0xFF)}
 	}
 
 	// long form
@@ -174,7 +174,8 @@ func encodeLength(length int) []byte {
 		length >>= 8 // discard the last byte
 	}
 
-	return append([]byte{byte(0b1000_0000 | len(lengthBytes))}, lengthBytes...)
+	// len(lengthBytes) is small (<= 8); mask keeps the conversion provably in range.
+	return append([]byte{byte((0b1000_0000 | len(lengthBytes)) & 0xFF)}, lengthBytes...)
 }
 
 func validateTag(tag []byte) error {

--- a/tlv_test.go
+++ b/tlv_test.go
@@ -332,3 +332,63 @@ func BenchmarkCopyTags(b *testing.B) {
 		})
 	}
 }
+
+// TestDecodeMalformedLengthDoesNotPanic verifies that Decode returns an error
+// (never panics) on inputs whose long-form length field overflows an int.
+//
+// Regression for a slice-bounds-out-of-range panic: a long-form BER length of up
+// to 127 bytes was accumulated into an int without an overflow guard, so a large
+// length wrapped to a negative value. The caller's "len(data) < length" bounds
+// check then passed (a small non-negative len is not < a negative length) and
+// the subsequent data[:length] slice expression panicked.
+func TestDecodeMalformedLengthDoesNotPanic(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{
+			// tag 5A; length byte 0x88 = long form, 8 length-bytes; then 8x0xFF.
+			// The 8 bytes accumulate to int64(-1), bypassing the bounds check.
+			name: "8-byte length overflows to negative",
+			data: []byte{0x5A, 0x88, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+		},
+		{
+			// length byte 0x9C = long form, 0x1C (28) length-bytes: more than 8,
+			// so it must be rejected outright.
+			name: "28-byte length field",
+			data: []byte("0\x9c00000000000000000000\x9c0000000"),
+		},
+		{
+			// Positive-but-too-large length (claims 0xFFFF bytes of value).
+			name: "length exceeds remaining data",
+			data: []byte{0x5A, 0x82, 0xFF, 0xFF},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, err := bertlv.Decode(tt.data)
+				require.Error(t, err)
+			})
+		})
+	}
+}
+
+// FuzzDecode ensures Decode never panics on arbitrary input; returning an error
+// is the only acceptable failure mode for malformed data.
+func FuzzDecode(f *testing.F) {
+	seeds := [][]byte{
+		{},
+		{0x5A, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11},
+		{0x6F, 0x03, 0x84, 0x01, 0x00}, // composite (recurses)
+		{0x5A, 0x88, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+		[]byte("0\x9c00000000000000000000\x9c0000000"),
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = bertlv.Decode(data)
+	})
+}


### PR DESCRIPTION
## Problem

`Decode` panics with `slice bounds out of range` on malformed input whose
long-form length field overflows an `int`.

`decodeLength` accumulates a long-form BER length (up to 127 length-bytes) with
`length = length<<8 | int(data[i])` and **no overflow guard**. A large length
wraps to a negative value. Back in `Decode`, the bounds check

```go
if len(data) < length { // small non-negative len is NOT < a negative length → passes
    return nil, fmt.Errorf("insufficient data ...")
}
value := data[:length] // data[:negative] → panic
```

is bypassed, and the slice expression panics.

### Reproduction

```go
bertlv.Decode([]byte{0x5A, 0x88, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
// panic: runtime error: slice bounds out of range [:-1]
```

(`0x88` = long form, 8 length-bytes; 8×`0xFF` accumulates to `int64(-1)`.)

Any service that decodes untrusted TLV bytes (e.g. EMV card/terminal data after
decryption) can be crashed by a crafted payload — a DoS risk.

## Fix

In `decodeLength`:
- Reject long-form length fields wider than 8 bytes (cannot fit in `int64`).
- Reject any length that overflowed to negative after accumulation.

Both cases now return an error instead of producing a bogus length.

## Tests

- `TestDecodeMalformedLengthDoesNotPanic` — table of overflow/oversized/too-large
  length inputs; asserts `Decode` returns an error and does not panic. **Verified
  it panics on the pre-fix code** (`slice bounds out of range [:-1]` and
  `[:-7192195621385654224]`).
- `FuzzDecode` — ensures `Decode` never panics on arbitrary input (~2.8M execs
  clean locally). The package had no fuzz coverage before.

Existing tests and valid long-form lengths are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
